### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :update, :edit]
-  before_action :set_item, only: [:edit, :update, :show]
+  before_action :authenticate_user!, only: [:new, :create, :update, :edit, :destroy]
+  before_action :set_item, only: [:edit, :update, :show, :destroy]
   before_action :check_owner, only: [:edit, :update]
   def index
     @items = Item.order('created_at DESC')
@@ -35,6 +35,11 @@ class ItemsController < ApplicationController
       flash.now[:alert]
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
      <% if current_user.id == @item.user_id%>
         <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
 
       <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>


### PR DESCRIPTION
＃＃＃What

商品削除機能を実装しました。
出品者が自身の出品した商品を削除できるようにし、削除後はトップページにリダイレクトする仕様としています。削除はAjaxを使用せず、通常のHTTPリクエストで実装しています。

＃＃＃Why

ユーザーが出品した商品を削除する機能を提供することで、不要になった商品の管理を簡単に行えるようにするためです。これにより、出品後のユーザーの利便性を向上させ、サービスの使いやすさを確保します。

https://gyazo.com/df89aec090b347be1dea0ceb65a9cf9f
